### PR TITLE
Rewritten to raise ValueError and tighten conformance checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,79 @@
+# Version 2.0
+
+This was a major rewrite of `ciso8601`.
+
+Fundamentally, `parse_datetime(dt: String): datetime` was rewritten so that it takes a string and either:
+
+   * Returns a properly parsed Python datetime, **if and only if** that **entire** string conforms to the supported subset of ISO 8601
+   * Raise an Exception (ex. `ValueError`) with a description of the reason why the string doesn't conform to ISO 8601
+
+This is a departure from the past where `ciso8601` would sometimes return `None` and sometimes return a malformed `datetime`, depending on the nature of your data quality problem.
+
+## Breaking changes:
+
+1. No longer allows you to parse a tz-aware timestamp as tz-naive datetime
+    * In fact, `parse_datetime_unaware` doesn't even exist anymore).
+1. Throws exception when a timestamp does not conform to ISO 8601
+    * This includes trailing characters in the timestamp
+    * No longer accepts single character "day" values
+    * See migration guide below for more examples
+
+## v1.x -> 2.0 Migration guide
+
+### `parse_datetime_unaware` has been removed
+
+`parse_datetime_unaware` existed for the case where your input had `tzinfo`, but you wanted to ignore the tzinfo and therefore could save some cycles by not parsing the tzinfo characters.
+
+The use case was deemed not compelling enough. Ignoring tzinfo on a tz-aware timestamp is almost never what you want to do. If you still want to ignore tzinfo, just use `parse_datetime` and then replace the tzinfo manually:
+
+```python
+    dt = parse_datetime("2018-01-01T00:00:00+05:00").replace(tzinfo=None)
+```
+
+`parse_datetime` now handles both tz-aware and tz-naive timestamps. Instances where you were using `parse_datetime_unaware` to parse tz-naive timestamps, you can simply use `parse_datetime` instead.
+
+```python
+    dt = parse_datetime("2018-01-01T00:00:00")
+```
+
+### ValueError instead of None
+
+Places where you were checking for a return of `None` from ciso8601:
+
+```python
+    timestamp = "2018-01-01T00:00:00+05:00"
+    dt = parse_datetime(timestamp)
+    if dt is None:
+        raise ValueError(f"Could not parse {timestamp}")
+```
+
+You should change to now expect ValueError to be thrown:
+
+```python
+    timestamp = "2018-01-01T00:00:00+05:00"
+    dt = parse_datetime(timestamp)
+```
+
+### Tightened ISO 8601 conformance
+
+The rules with respect to what `ciso8601` will consider a conforming ISO 8601 string have been tightened.
+
+Now a timestamp will parse **if and only if** the timestamp is 100% conforming to the supported subset of the ISO 8601 specification.
+
+
+```python
+    "2014-" # Missing the month
+    "2014-01-" # trailing separator
+
+    # Mix of no-separator and separator
+    "201401-02" 
+    "2014-0102"
+    "2014-01-02T00:0000" 
+    "2014-01-02T0000:00"
+    
+    "2014-01-02T01:23:45Zabcdefghij" # Trailing characters
+
+    "2014-01-1" # Single digit day
+```
+
+These could have been considered bugs, but it may be the case that your code was relying on the previously lax parsing rules.

--- a/README.rst
+++ b/README.rst
@@ -170,7 +170,7 @@ Format                              Example             Supported
 ``hh:mm:ss.ssssss``                 ``11:30:59.123456`` ✅ 
 ``hhmmss,ssssss``                   ``113059,123456``   ✅ 
 ``hh:mm:ss,ssssss``                 ``11:30:59,123456`` ✅ 
-Midnight (special case)             ``24:00:00``        ❌               
+Midnight (special case)             ``24:00:00``        ✅               
 ``hh.hhh`` (fractional hours)       ``11.5``            ❌               
 ``hh:mm.mmm`` (fractional minutes)  ``11:30.5``         ❌               
 =================================== =================== ============== 

--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ ciso8601
 
 ``ciso8601`` converts ISO8601 date time strings into Python datetime objects.
 Since it's written as a C module, it is much faster than other Python libraries.
-Tested with Python 2.7 + 3.4 + 3.5.
+Tested with Python 2.7, 3.4, 3.5, 3.6.
 
 
 (Interested in working on projects like this? `Close.io`_ is looking for `great engineers`_ to join our team)
@@ -36,8 +36,20 @@ Usage
   In [3]: ciso8601.parse_datetime('20141205T123045')
   Out[3]: datetime.datetime(2014, 12, 5, 12, 30, 45)
 
-  In [4]: ciso8601.parse_datetime_unaware('2014-12-05T12:30:45.123456-05:30')
-  Out[4]: datetime.datetime(2014, 12, 5, 12, 30, 45, 123456)
+If time zone information is provided, an aware datetime object will be returned.
+Otherwise, the datetime is unaware. Please note that it takes more time to parse
+aware datetimes, especially if they're not in UTC.
+
+If parsing fails, an Exception will be raised (typically `ValueError`). The parser will attempt to parse as
+much of the date time as possible.
+
+Migration to v2
+---------------
+
+Version 2.0.0 of ``ciso8601`` changed the core implementation. This was not entirely backwards compatible, and care should be taken when migrating
+See `CHANGELOG`_ for details.
+
+.. _CHANGELOG: https://github.com/closeio/ciso8601/blob/master/CHANGELOG.md
 
 Benchmark
 ---------
@@ -114,41 +126,70 @@ Tested on Python 2.7.10 on macOS 10.12.6 using the following modules:
   isodate==0.5.4
   python-dateutil==2.6.1
 
-Supported formats
+Supported Subset
 -----------------
 
-Dates may have one of the following formats:
+ciso8601 only supports a subset of ISO 8601.
 
-- ``YYYYMMDD``
-- ``YYYY-MM-DD``
-- ``YYYY-MM``
+Calendar Dates
+^^^^^^^^^^^^^^
 
-Week dates or ordinal dates are not currently supported.
+The following calendar date formats are supported:
 
-Times are optional and are separated by the letter ``T`` or also by space
-(unlike ISO8601). The following time formats are supported:
+.. table:: Supported date formats
+   :widths: auto
+============== ============== ==================
+Format         Example        Supported
+============== ============== ==================
+``YYYY-MM-DD`` ``2018-04-29`` ✅
+``YYYY-MM``    ``2018-04``    ✅
+``YYYYMMDD``   ``2018-04``    ✅
+``--MM-DD``    ``--04-29``    ❌              
+``--MMDD``     ``--0429``     ❌              
+============== ============== ==================
 
-- ``hh``
-- ``hhmm`` or ``hh:mm``
-- ``hhmmss`` or ``hh:mm:ss``
+Times
+^^^^^
 
-Fractions of a second may be provided, separated by ``.`` or ``,``. Up to 6
-digits are supported, excessive digits will be ignored.
+Times are optional and are separated from the date by the letter ``T``.
+``ciso860`` extends the ISO 8601 specification slightly by allowing a space character to be used instead of a ``T``.
+
+The following time formats are supported:
+
+.. table:: Supported time formats
+   :widths: auto
+=================================== =================== ==============  
+Format                              Example             Supported          
+=================================== =================== ============== 
+``hh``                              ``11``              ✅ 
+``hhmm``                            ``1130``            ✅ 
+``hh:mm``                           ``11:30``           ✅ 
+``hhmmss``                          ``113059``          ✅ 
+``hh:mm:ss``                        ``11:30:59``        ✅ 
+``hhmmss.ssssss``                   ``113059.123456``   ✅ 
+``hh:mm:ss.ssssss``                 ``11:30:59.123456`` ✅ 
+``hhmmss,ssssss``                   ``113059,123456``   ✅ 
+``hh:mm:ss,ssssss``                 ``11:30:59,123456`` ✅ 
+Midnight (special case)             ``24:00:00``        ❌               
+``hh.hhh`` (fractional hours)       ``11.5``            ❌               
+``hh:mm.mmm`` (fractional minutes)  ``11:30.5``         ❌               
+=================================== =================== ============== 
+
+**Note:** Python datetime objects only have microsecond precision (6 digits). Any additional precision will be truncated.
+If you need greater precision than microsecond precision, please do not use `ciso8601`.
+
+Time Zone Information
+^^^^^^^^^^^^^^^^^^^^^
 
 Time zone information may be provided in one of the following formats:
 
-- ``Z``
-- ``±hh``
-- ``±hh:mm``
-- ``±hhmm``
-
-If time zone information is provided, an aware datetime object will be returned.
-Otherwise, the datetime is unaware. Please note that it takes more time to parse
-aware datetimes, especially if they're not in UTC. If you don't care about time
-zone information, use the ``parse_datetime_unaware`` method, which will discard
-any time zone information and is faster. Parsing aware date times requires the
-``pytz`` module, otherwise time zone information is ignored and unaware
-datetimes are returned.
-
-If parsing fails, ``None`` will be returned. The parser will attempt to parse as
-much of the date time as possible.
+.. table:: Supported time zone formats
+   :widths: auto
+========== ========== =========== 
+Format     Example    Supported          
+========== ========== =========== 
+``Z``      ``Z``      ✅
+``±hh``    ``+11``    ✅
+``±hhmm``  ``+1130``  ✅
+``±hh:mm`` ``+11:30`` ✅
+========== ========== ===========

--- a/module.c
+++ b/module.c
@@ -5,7 +5,7 @@ static PyObject* pytz_fixed_offset;
 static PyObject* pytz_utc;
 
 static void* format_unexpected_character_exception(char* field_name, char c, int index, int expected_character_count){
-    if (c == NULL)
+    if (c == '\0')
         PyErr_Format(PyExc_ValueError, "Unexpected end of string while parsing %s. Expected %d more character%s", field_name, expected_character_count, (expected_character_count != 1) ? "s": "");
     else
         PyErr_Format(PyExc_ValueError, "Invalid character while parsing %s ('%c', Index: %d)", field_name, c, index);
@@ -59,7 +59,7 @@ static void parse_month_day(char** c, char* str, int* month, int* day){
         if (PyErr_Occurred())
             return NULL;
 
-        if (**c != NULL && !is_date_and_time_separator(**c)){ // Optional day
+        if (**c != '\0' && !is_date_and_time_separator(**c)){ // Optional day
             parse_date_separator(c, str);
             if (PyErr_Occurred())
                 return NULL;
@@ -138,7 +138,7 @@ static void parse_minute_second(char** c, char* str, int* minute, int* second, i
         if (PyErr_Occurred())
             return NULL;
 
-        if (**c != NULL && !is_time_zone_separator(**c)){ // Optional second
+        if (**c != '\0' && !is_time_zone_separator(**c)){ // Optional second
             parse_time_separator(c, str);
             if (PyErr_Occurred())
                 return NULL;
@@ -152,7 +152,7 @@ static void parse_minute_second(char** c, char* str, int* minute, int* second, i
         if (PyErr_Occurred())
             return NULL;
 
-        if (**c != NULL && !is_time_zone_separator(**c)){ // Optional second
+        if (**c != '\0' && !is_time_zone_separator(**c)){ // Optional second
             parse_second(c, str, second, usecond);
             if (PyErr_Occurred())
                 return NULL;
@@ -162,7 +162,6 @@ static void parse_minute_second(char** c, char* str, int* minute, int* second, i
 
 static void parse_tzinfo(char** c, char* str, PyObject** tzinfo){
     // Time zone designator (Z or +hh:mm or -hh:mm)
-    int i = 0;
     int aware = 0;
     int tzhour = 0, tzminute = 0, tzsign = 0;
     if (**c == 'Z')
@@ -194,7 +193,7 @@ static void parse_tzinfo(char** c, char* str, PyObject** tzinfo){
             tzminute = parse_integer(c, str, 2, "tz minute");
             if (PyErr_Occurred())
                 return NULL;
-        } else if (**c != NULL){ // Optional minute
+        } else if (**c != '\0'){ // Optional minute
             tzminute = parse_integer(c, str, 2, "tz minute");
             if (PyErr_Occurred())
                 return NULL;
@@ -226,12 +225,12 @@ static void parse_timestamp(char** c, char* str, int* hour, int* minute, int* se
     if (PyErr_Occurred())
         return NULL;
 
-    if (**c != NULL && !is_time_zone_separator(**c)){
+    if (**c != '\0' && !is_time_zone_separator(**c)){
         parse_minute_second(c, str, minute, second, usecond);
         if (PyErr_Occurred())
             return NULL;
     }
-    if (**c != NULL){
+    if (**c != '\0'){
         parse_tzinfo(c, str, tzinfo);
         if (PyErr_Occurred())
             return NULL;
@@ -258,7 +257,7 @@ static PyObject* parse_datetime(PyObject* self, PyObject* args)
         return NULL;
     //TODO: Check range of year if necessary
 
-    if (*c != NULL && !is_date_and_time_separator(*c)){
+    if (*c != '\0' && !is_date_and_time_separator(*c)){
         parse_month_day(&c, str, &month, &day);
         if (PyErr_Occurred())
             return NULL;
@@ -312,7 +311,7 @@ static PyObject* parse_datetime(PyObject* self, PyObject* args)
     }
 
 
-    if (*c != NULL && !is_time_zone_separator(*c)){
+    if (*c != '\0' && !is_time_zone_separator(*c)){
         parse_timestamp(&c, str, &hour, &minute, &second, &usecond, &tzinfo);
         if (PyErr_Occurred())
             return NULL;
@@ -341,7 +340,7 @@ static PyObject* parse_datetime(PyObject* self, PyObject* args)
 
     
     // Make sure that there is no more to parse.
-    if (*c != NULL){
+    if (*c != '\0'){
         PyErr_Format(PyExc_ValueError, "unconverted data remains: '%s'", c);
         return NULL;
     }

--- a/module.c
+++ b/module.c
@@ -139,7 +139,7 @@ static void parse_minute_second(char** c, char* str, int* minute, int* second, i
             return NULL;
 
         if (**c != NULL && !is_time_zone_separator(**c)){ // Optional second
-            parse_time_separator(c, str, 1);
+            parse_time_separator(c, str);
             if (PyErr_Occurred())
                 return NULL;
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,10 @@ setup(
     license="MIT",
     ext_modules=[Extension("ciso8601", ["module.c"])],
     test_suite='tests',
-    tests_require=['pytz'],
+    tests_require=[
+        'pytz',
+        "unittest2 ; python_version < '3'"
+    ],
     classifiers=[
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',

--- a/tests.py
+++ b/tests.py
@@ -1,7 +1,14 @@
 import ciso8601
 import datetime
 import pytz
-import unittest
+
+
+import sys  # TODO: Clean this up
+if sys.version_info.major == 2:
+    import unittest2 as unittest
+else:
+    import unittest
+
 
 class CISO8601TestCase(unittest.TestCase):
     def test_formats(self):
@@ -61,7 +68,7 @@ class CISO8601TestCase(unittest.TestCase):
         )
         for leap_year in (1600, 2000, 2016):
             self.assertEqual(
-                ciso8601.parse_datetime_unaware('{}-02-29'.format(leap_year)),
+                ciso8601.parse_datetime('{}-02-29'.format(leap_year)),
                 datetime.datetime(leap_year, 2, 29, 0, 0, 0, 0)
             )
 
@@ -94,91 +101,467 @@ class CISO8601TestCase(unittest.TestCase):
             datetime.datetime(2014, 12, 5, 12, 30, 45, 123456, pytz.FixedOffset(-360))
         )
 
-    def test_unaware(self):
-        expected = datetime.datetime(2014, 12, 5, 12, 30, 45, 123456)
-        self.assertEqual(
-            ciso8601.parse_datetime('2014-12-05T12:30:45.123456'),
-            expected
-        )
-
-        # parse_datetime_unaware ignores tz offset
-        self.assertEqual(
-            ciso8601.parse_datetime_unaware('2014-12-05T12:30:45.123456Z'),
-            expected
-        )
-        self.assertEqual(
-            ciso8601.parse_datetime_unaware('2014-12-05T12:30:45.123456+00:00'),
-            expected,
-        )
-        self.assertEqual(
-            ciso8601.parse_datetime_unaware('2014-12-05T12:30:45.123456-05:00'),
-            expected,
-        )
-
-    def test_invalid(self):
-        self.assertRaises(
+    def test_invalid_year(self):
+        self.assertRaisesRegex(
             ValueError,
-            ciso8601.parse_datetime_unaware,
+            r"Unexpected end of string while parsing year. Expected 4 more characters",
+            ciso8601.parse_datetime,
+            '',
+        )
+        self.assertRaisesRegex(
+            ValueError,
+            r"Unexpected end of string while parsing year. Expected 3 more characters",
+            ciso8601.parse_datetime,
+            '2',
+        )
+        self.assertRaisesRegex(
+            ValueError,
+            r"Unexpected end of string while parsing year. Expected 2 more characters",
+            ciso8601.parse_datetime,
+            '20',
+        )
+        self.assertRaisesRegex(
+            ValueError,
+            r"Unexpected end of string while parsing year. Expected 1 more character",
+            ciso8601.parse_datetime,
+            '201',
+        )
+        self.assertRaisesRegex(
+            ValueError,
+            r"Invalid character while parsing year",
+            ciso8601.parse_datetime,
             'asdf',
         )
-        self.assertRaises(
+
+        self.assertRaisesRegex(
             ValueError,
-            ciso8601.parse_datetime_unaware,
-            '2014-99-03',
-        )
-        self.assertRaises(
-            ValueError,
-            ciso8601.parse_datetime_unaware,
-            '2014-13-03',
-        )
-        self.assertRaises(
-            ValueError,
-            ciso8601.parse_datetime_unaware,
-            '2014-00-03',
-        )
-        self.assertRaises(
-            ValueError,
+            r"Invalid character while parsing year",
             ciso8601.parse_datetime,
-            '20140203T24:35:27',
-        )
-        self.assertRaises(
-            ValueError,
-            ciso8601.parse_datetime,
-            '20140203T23:60:27',
-        )
-        self.assertRaises(
-            ValueError,
-            ciso8601.parse_datetime,
-            '20140203T23:35:61',
-        )
-        self.assertRaises(
-            ValueError,
-            ciso8601.parse_datetime_unaware,
-            '2014-01-32',
-        )
-        self.assertRaises(
-            ValueError,
-            ciso8601.parse_datetime_unaware,
-            '2014-06-31',
-        )
-        for non_leap_year in (1700, 1800, 1900, 2014):
-            self.assertRaises(
-                ValueError,
-                ciso8601.parse_datetime_unaware,
-                '{}-02-29'.format(non_leap_year)
-            )
-        self.assertRaises(
-            ValueError,
-            ciso8601.parse_datetime_unaware,
             'Z',
         )
 
-        self.assertRaises(
+    def test_invalid_calendar_separator(self):
+        self.assertRaisesRegex(
             ValueError,
+            r"Invalid character while parsing month",
+            ciso8601.parse_datetime,
+            '2018=01=01',
+        )
+
+        self.assertRaisesRegex(
+            ValueError,
+            r"Invalid character while parsing date separator \('-'\) \('=', Index: 7\)",
+            ciso8601.parse_datetime,
+            '2018-01=01',
+        )
+
+        self.assertRaisesRegex(
+            ValueError,
+            r"Invalid character while parsing date separator \('-'\) \('0', Index: 7\)",
+            ciso8601.parse_datetime,
+            '2018-0101',
+        )
+
+        self.assertRaisesRegex(
+            ValueError,
+            r"Invalid character while parsing day \('-', Index: 6\)",
+            ciso8601.parse_datetime,
+            '201801-01',
+        )
+
+    def test_invalid_month(self):
+        self.assertRaisesRegex(
+            ValueError,
+            r"Unexpected end of string while parsing month. Expected 2 more characters",
+            ciso8601.parse_datetime,
+            '2018-',
+        )
+
+        self.assertRaisesRegex(
+            ValueError,
+            r"Unexpected end of string while parsing month. Expected 1 more character",
+            ciso8601.parse_datetime,
+            '2018-1',
+        )
+
+        self.assertRaisesRegex(
+            ValueError,
+            r"Invalid character while parsing month",
+            ciso8601.parse_datetime,
+            '2018-a',
+        )
+
+        self.assertRaisesRegex(
+            ValueError,
+            r"Invalid character while parsing month",
+            ciso8601.parse_datetime,
+            '2018-0a',
+        )
+
+        self.assertRaisesRegex(
+            ValueError,
+            r"month must be in 1..12",
+            ciso8601.parse_datetime,
+            '2014-99-03',
+        )
+
+        self.assertRaisesRegex(
+            ValueError,
+            r"month must be in 1..12",
+            ciso8601.parse_datetime,
+            '2014-13-03',
+        )
+
+        self.assertRaisesRegex(
+            ValueError,
+            r"month must be in 1..12",
+            ciso8601.parse_datetime,
+            '2014-00-03',
+        )
+
+    def test_invalid_day(self):
+        self.assertRaisesRegex(
+            ValueError,
+            r"Unexpected end of string while parsing day. Expected 2 more characters",
+            ciso8601.parse_datetime,
+            '2018-01-',
+        )
+
+        self.assertRaisesRegex(
+            ValueError,
+            r"Invalid character while parsing day",
+            ciso8601.parse_datetime,
+            '2018-01-a',
+        )
+
+        self.assertRaisesRegex(
+            ValueError,
+            r"Invalid character while parsing day",
+            ciso8601.parse_datetime,
+            '2018-01-0a',
+        )
+
+        for non_leap_year in (1700, 1800, 1900, 2014):
+            self.assertRaisesRegex(
+                ValueError,
+                r"day is out of range for month",
+                ciso8601.parse_datetime,
+                '{}-02-29'.format(non_leap_year)
+            )
+
+        self.assertRaisesRegex(
+            ValueError,
+            r"day is out of range for month",
+            ciso8601.parse_datetime,
+            '2014-01-32',
+        )
+
+        self.assertRaisesRegex(
+            ValueError,
+            r"day is out of range for month",
+            ciso8601.parse_datetime,
+            '2014-06-31',
+        )
+
+        self.assertRaisesRegex(
+            ValueError,
+            r"day is out of range for month",
+            ciso8601.parse_datetime,
+            '2014-06-00',
+        )
+
+    def test_invalid_yyyymm_format(self):
+        self.assertRaisesRegex(
+            ValueError,
+            r"Unexpected end of string while parsing day. Expected 2 more characters",
+            ciso8601.parse_datetime,
+            '201406',
+        )
+
+    def test_invalid_date_and_time_delimiter(self):
+        self.assertRaisesRegex(
+            ValueError,
+            r"Invalid character while parsing date and time separator \(ie. 'T' or ' '\) \('_', Index: 10\)",
+            ciso8601.parse_datetime,
+            '2018-01-01_00:00:00',
+        )
+
+    def test_invalid_hour(self):
+
+        self.assertRaisesRegex(
+            ValueError,
+            r"Unexpected end of string while parsing hour. Expected 2 more characters",
+            ciso8601.parse_datetime,
+            '2018-01-01T',
+        )
+
+        self.assertRaisesRegex(
+            ValueError,
+            r"Unexpected end of string while parsing hour. Expected 1 more character",
+            ciso8601.parse_datetime,
+            '2018-01-01T0',
+        )
+
+        self.assertRaisesRegex(
+            ValueError,
+            r"Invalid character while parsing hour",
+            ciso8601.parse_datetime,
+            '2018-01-01Ta',
+        )
+
+        self.assertRaisesRegex(
+            ValueError,
+            r"Invalid character while parsing hour",
+            ciso8601.parse_datetime,
+            '2018-01-01T0a',
+        )
+
+        self.assertRaisesRegex(
+            ValueError,
+            r"hour must be in 0..23",
+            ciso8601.parse_datetime,
+            '2018-01-01T99',
+        )
+
+        self.assertRaisesRegex(
+            ValueError,
+            r"hour must be in 0..23",
+            ciso8601.parse_datetime,
+            '20140203T24:35:27',
+        )
+
+    def test_invalid_minute(self):
+
+        self.assertRaisesRegex(
+            ValueError,
+            r"Unexpected end of string while parsing minute. Expected 2 more characters",
+            ciso8601.parse_datetime,
+            '2018-01-01T00:',
+        )
+
+        self.assertRaisesRegex(
+            ValueError,
+            r"Unexpected end of string while parsing minute. Expected 1 more character",
+            ciso8601.parse_datetime,
+            '2018-01-01T00:1',
+        )
+
+        self.assertRaisesRegex(
+            ValueError,
+            r"Invalid character while parsing minute",
+            ciso8601.parse_datetime,
+            '2018-01-01T00:a',
+        )
+
+        self.assertRaisesRegex(
+            ValueError,
+            r"Invalid character while parsing minute",
+            ciso8601.parse_datetime,
+            '2018-01-01T00:0a',
+        )
+
+        self.assertRaisesRegex(
+            ValueError,
+            r"minute must be in 0..59",
+            ciso8601.parse_datetime,
+            '2018-01-01T00:99',
+        )
+
+        self.assertRaisesRegex(
+            ValueError,
+            r"minute must be in 0..59",
+            ciso8601.parse_datetime,
+            '20140203T23:60:27',
+        )
+
+    def test_invalid_time_separator(self):
+        self.assertRaisesRegex(
+            ValueError,
+            r"Invalid character while parsing time separator \(':'\) \('=', Index: 16\)",
+            ciso8601.parse_datetime,
+            '2018-01-01T00:00=00'
+        )
+
+        self.assertRaisesRegex(
+            ValueError,
+            r"Invalid character while parsing time separator \(':'\) \('0', Index: 16\)",
+            ciso8601.parse_datetime,
+            '2018-01-01T00:0000'
+        )
+
+        self.assertRaisesRegex(
+            ValueError,
+            r"Invalid character while parsing second \(':', Index: 15\)",
+            ciso8601.parse_datetime,
+            '2018-01-01T0000:00'
+        )
+
+    def test_invalid_second(self):
+
+        self.assertRaisesRegex(
+            ValueError,
+            r"Unexpected end of string while parsing second. Expected 2 more characters",
+            ciso8601.parse_datetime,
+            '2018-01-01T00:00:',
+        )
+
+        self.assertRaisesRegex(
+            ValueError,
+            r"Unexpected end of string while parsing second. Expected 1 more character",
+            ciso8601.parse_datetime,
+            '2018-01-01T00:00:1',
+        )
+
+        self.assertRaisesRegex(
+            ValueError,
+            r"Invalid character while parsing second",
+            ciso8601.parse_datetime,
+            '2018-01-01T00:00:a',
+        )
+
+        self.assertRaisesRegex(
+            ValueError,
+            r"Invalid character while parsing second",
+            ciso8601.parse_datetime,
+            '2018-01-01T00:00:1a',
+        )
+
+        self.assertRaisesRegex(
+            ValueError,
+            r"second must be in 0..59",
+            ciso8601.parse_datetime,
+            '2018-01-01T00:00:99',
+        )
+
+        self.assertRaisesRegex(
+            ValueError,
+            r"second must be in 0..59",
+            ciso8601.parse_datetime,
+            '20140203T23:35:61',
+        )
+
+    def test_invalid_subsecond(self):
+        self.assertRaisesRegex(
+            ValueError,
+            r"Unexpected end of string while parsing subsecond. Expected 1 more character",
+            ciso8601.parse_datetime,
+            '2018-01-01T00:00:00.',
+        )
+
+        self.assertRaisesRegex(
+            ValueError,
+            r"Invalid character while parsing subsecond \('a', Index: 20\)",
+            ciso8601.parse_datetime,
+            '2018-01-01T00:00:00.a',
+        )
+
+    def test_invalid_tz_hour(self):
+        self.assertRaisesRegex(
+            ValueError,
+            r"Unexpected end of string while parsing tz hour. Expected 1 more character",
+            ciso8601.parse_datetime,
+            '2018-01-01T00:00:00.00-0',
+        )
+
+        self.assertRaisesRegex(
+            ValueError,
+            r"Invalid character while parsing tz hour \('a', Index: 24\)",
+            ciso8601.parse_datetime,
+            '2018-01-01T00:00:00.00-0a',
+        )
+
+    def test_invalid_tz_minute(self):
+
+        self.assertRaisesRegex(
+            ValueError,
+            r"Unexpected end of string while parsing tz minute. Expected 2 more characters",
+            ciso8601.parse_datetime,
+            '2018-01-01T00:00:00.00-00:',
+        )
+
+        self.assertRaisesRegex(
+            ValueError,
+            r"Invalid character while parsing tz minute \('a', Index: 25\)",
+            ciso8601.parse_datetime,
+            '2018-01-01T00:00:00.00-00a',
+        )
+
+        self.assertRaisesRegex(
+            ValueError,
+            r"Invalid character while parsing tz minute \('a', Index: 26\)",
+            ciso8601.parse_datetime,
+            '2018-01-01T00:00:00.00-00:a',
+        )
+
+        self.assertRaisesRegex(
+            ValueError,
+            r"Unexpected end of string while parsing tz minute. Expected 1 more character",
+            ciso8601.parse_datetime,
+            '2018-01-01T00:00:00.00-00:0',
+        )
+
+        self.assertRaisesRegex(
+            ValueError,
+            r"Invalid character while parsing tz minute \('a', Index: 27\)",
+            ciso8601.parse_datetime,
+            '2018-01-01T00:00:00.00-00:0a',
+        )
+
+    def test_tz_offsets_too_large(self):
+        # The Python interpreter crashes if you give the datetime constructor a TZ offset with an absolute value >= 1440
+        # TODO: Determine whether these are valid ISO 8601 values and therefore whether ciso8601 should support them.
+        self.assertRaisesRegex(
+            ValueError,
+            r"Absolute tz offset is too large \(-5940\)",
+            ciso8601.parse_datetime,
+            '2018-01-01T00:00:00.00-99',
+        )
+
+        self.assertRaisesRegex(
+            ValueError,
+            r"Absolute tz offset is too large \(-1440\)",
+            ciso8601.parse_datetime,
+            '2018-01-01T00:00:00.00-23:60',
+        )
+
+    def test_invalid_trailing_characters(self):
+        self.assertRaisesRegex(
+            ValueError,
+            r"Invalid character while parsing date and time separator \(ie. 'T' or ' '\) \('a', Index: 10\)",
             ciso8601.parse_datetime,
             '2014-12-05asdfasdf'
         )
 
+        self.assertRaisesRegex(
+            ValueError,
+            r"Invalid character while parsing minute \('a', Index: 13\)",
+            ciso8601.parse_datetime,
+            '2018-01-01T00a',
+        )
+
+        self.assertRaisesRegex(
+            ValueError,
+            r"unconverted data remains: 'a'",
+            ciso8601.parse_datetime,
+            '2014-01-01T00:00:00Za',
+        )
+
+        self.assertRaisesRegex(
+            ValueError,
+            r"unconverted data remains: 'a'",
+            ciso8601.parse_datetime,
+            '2018-01-01T00:00:00.00-00:00a',
+        )
+
+        self.assertRaisesRegex(
+            ValueError,
+            r"unconverted data remains: 'a'",
+            ciso8601.parse_datetime,
+            '2018-01-01T00:00:00a',
+        )
+
+    def test_others(self):
+        # These are tests that previously existed. They may or may not have any additional value.
         parse = ciso8601.parse_datetime
 
         def check(s, *result):
@@ -193,39 +576,40 @@ class CISO8601TestCase(unittest.TestCase):
 
         check('20140203 04:05:06.123', 2014, 2, 3, 4, 5, 6, 123000)
         check('20140203 04:05:06,123', 2014, 2, 3, 4, 5, 6, 123000)
-        check('20140203 04:05:0.123', None)
-        check('20140203 04:05:.123', None)
-        check('20140203 04:05:,123', None)
-        check('20140203 04:05:06.', 2014, 2, 3, 4, 5, 6)
-        check('20140203 0405:06.', 2014, 2, 3, 4, 5, 6)
-        check('20140203 040506.', 2014, 2, 3, 4, 5, 6)
-        check('20140203 04050.', None)
-        check('20140203 0405:0', None)
-        check('20140203 04:05:.', None)
-        check('20140203 04:05:,', None)
-        check('20140203 04::', None)
-        check('20140203 04:00:', 2014, 2, 3, 4)
-        check('20140203 04::01', None)
-        check('20140203 04:', 2014, 2, 3, 4)
+        check('20140203 04:05:0.123', ValueError)
+        check('20140203 04:05:.123', ValueError)
+        check('20140203 04:05:,123', ValueError)
+        check('20140203 04:05:06.', ValueError)
+        check('20140203 0405:06.', ValueError)
+        check('20140203 040506.', ValueError)
+        check('20140203 04050.', ValueError)
+        check('20140203 0405:0', ValueError)
+        check('20140203 04:05:.', ValueError)
+        check('20140203 04:05:,', ValueError)
+        check('20140203 04::', ValueError)
+        check('20140203 04:00:', ValueError)
+        check('20140203 04::01', ValueError)
+        check('20140203 04:', ValueError)
 
         check('2014-02-03', 2014, 2, 3)
-        check('2014-0-03', None)
-        check('2014--03', None)
+        check('2014-0-03', ValueError)
+        check('2014--03', ValueError)
         check('2014-02', 2014, 2, 1)
-        check('2014--0', None)
-        check('2014--', None)
-        check('2014-', None)
-        check('2014', None)
+        check('2014--0', ValueError)
+        check('2014--', ValueError)
+        check('2014-', ValueError)
+        check('2014', ValueError)
 
         check('20140203 040506.123', 2014, 2, 3, 4, 5, 6, 123000)
-        check('20140203 040506123', 2014, 2, 3, 4, 5, 6)  # NB: drops usec
-        check('20140203 04050612', 2014, 2, 3, 4, 5, 6)
-        check('20140203 0405061', 2014, 2, 3, 4, 5, 6)
+        check('20140203 040506123', ValueError)
+        check('20140203 04050612', ValueError)
+        check('20140203 0405061', ValueError)
         check('20140203 040506', 2014, 2, 3, 4, 5, 6)
-        check('20140203 04050', None)
+        check('20140203 04050', ValueError)
         check('20140203 0405', 2014, 2, 3, 4, 5)
-        check('20140203 040', None)
+        check('20140203 040', ValueError)
         check('20140203 04', 2014, 2, 3, 4)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests.py
+++ b/tests.py
@@ -72,6 +72,12 @@ class CISO8601TestCase(unittest.TestCase):
                 datetime.datetime(leap_year, 2, 29, 0, 0, 0, 0)
             )
 
+    def test_special_midnight(self):
+        self.assertEqual(
+            ciso8601.parse_datetime('2014-02-03T24:00:00'),
+            datetime.datetime(2014, 2, 4, 0, 0, 0)
+        )
+
     def test_aware_utc(self):
         expected = datetime.datetime(2014, 12, 5, 12, 30, 45, 123456, pytz.UTC)
         self.assertEqual(

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,9 @@
 [tox]
-envlist = py27,py34,py35
+envlist = py27,py34,py35,py36
 
 [testenv]
 deps=
     pytz
     nose
+    unittest2
 commands=nosetests


### PR DESCRIPTION
Alright,

I rewrote `parse_datetime(dt: String): datetime` so that it takes a string and either:

   * Returns a properly parsed Python datetime, **if and only if** that **entire** string conforms to the supported subset of ISO 8601
   * An Exception (ex. `ValueError`) with a description of the reason why the string doesn't conform to ISO 8601

It is a simply a manually written implementation of the ISO 8601 syntax.
Currently, the performance is ~40% slower than v1.0.7.

This is just a first draft. I have also been playing around with using a parser-generator ([flex](https://en.wikipedia.org/wiki/Flex_(lexical_analyser_generator))) for this instead. I've [got the syntax tree written](https://gist.github.com/movermeyer/46ce976013ce5cd0fef93651d5c3a473), but I haven't made it actually produce the python datetime object yet, nor have I profiled it.

There were some breaking changes as a result of this rewrite (See CHANGELOG.md for the full inventory):
    
* Throws exception when a string does not conform to ISO 8601
    * This includes trailing characters
* No longer accepts single character "day" values.
* No longer allows you to parse a tz-aware timestamp as tz-unaware (in fact, parse_datetime_unaware doesn't even exist anymore).

That last point is the one that I'm most concerned with. Personally, I didn't find the use case for `parse_datetime_unaware` to be compelling enough. Ignoring tzinfo on a tz-aware timestamp is almost never what you want to do (even if it is faster).

In working on this, I independently discovered a number of edge cases where ciso8601 had bugs (including #36).

Anyways, I'm totally open to suggestions.